### PR TITLE
Call cls instead of Bitmap so class can be extended.

### DIFF
--- a/src/bitmap.py
+++ b/src/bitmap.py
@@ -111,7 +111,7 @@ class BitMap(object):
         Construct BitMap from string
         """
         nbits = len(bitstring)
-        bm = BitMap(nbits)
+        bm = cls(nbits)
         for i in xrange(nbits):
             if bitstring[-i-1] == '1':
                 bm.set(i)


### PR DESCRIPTION
I had an issue with the fromstring constructor and asked a question here:
http://stackoverflow.com/questions/33373247/how-to-extend-a-static-base-constructor/33373456#33373456

There was a sugestion for the fix and I made it.
