### PR TITLE
fix python3 compatible

### DIFF
--- a/src/bitmap.py
+++ b/src/bitmap.py
@@ -141,7 +141,7 @@ class BitMap(object):
         """
         Construct BitMap from hex string
         """
-        bitstring = format(int(hexstring, 16), "0" + str(len(hexstring)/4) + "b")
+        bitstring = format(int(hexstring, 16), "0" + str(int(len(hexstring)/4)) + "b")
         return cls.fromstring(bitstring)
 
     @classmethod


### PR DESCRIPTION
In python3, interger divison will return a float.This will cause format error.
```
Python 3.7.4 (tags/v3.7.4:e09359112e, Jul  8 2019, 20:34:20) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from bitmap import BitMap
>>> bm = BitMap()
>>> hex_str = "10abc"
>>> bm.fromhexstring(hex_str)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\kele\AppData\Local\Programs\Python\Python37\lib\site-packages\bitmap\bitmap.py", line 144, in fromhexstring
    bitstring = format(int(hexstring, 16), "0" + str(len(hexstring)/4) + "b")
ValueError: Precision not allowed in integer format specifier
>>> "0"+str(len(hex_str)/4)+"b"
'01.25b'
>>>
```